### PR TITLE
Add basic routing and navigation

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,10 +1,30 @@
 <script>
-import FaQs from "@/FaQs/FaQs.svelte";
+  import { onMount } from 'svelte';
+  import FaQs from "@/FaQs/FaQs.svelte";
+  import AboutUs from "@/AboutUs/AboutUs.svelte";
+  import Homepage from "@/Homepage/Homepage.svelte";
+
+  const routes = {
+    home: Homepage,
+    faqs: FaQs,
+    about: AboutUs
+  };
+
+  let currentRoute = 'home';
+
+  function updateRoute() {
+    const hash = window.location.hash.slice(1);
+    currentRoute = routes[hash] ? hash : 'home';
+  }
+
+  onMount(() => {
+    updateRoute();
+    window.addEventListener('hashchange', updateRoute);
+    return () => window.removeEventListener('hashchange', updateRoute);
+  });
 </script>
 
-<div>
-  <FaQs />
-</div>
+<svelte:component this={routes[currentRoute]} />
 
 <style>
 </style>

--- a/src/NavigationProperty1OnWhite/NavigationProperty1OnWhite.svelte
+++ b/src/NavigationProperty1OnWhite/NavigationProperty1OnWhite.svelte
@@ -19,9 +19,12 @@
   <div class="hidden lg:flex h-[61px] relative items-center justify-between px-4 sm:px-6 lg:px-8">
     <!-- Left side - Logo -->
     <LogoProperty1Variant2 class="shrink-0"></LogoProperty1Variant2>
-    
-    <!-- Center - Contact Link -->
-    <div class="flex items-center">
+
+    <!-- Center - Page Links -->
+    <nav class="flex items-center gap-6">
+      <a href="#home" class="text-neutral-white font-['Geist-Regular',_sans-serif] text-base leading-[180%] hover:opacity-80 transition-opacity" style="letter-spacing: -0.2px;">Home</a>
+      <a href="#faqs" class="text-neutral-white font-['Geist-Regular',_sans-serif] text-base leading-[180%] hover:opacity-80 transition-opacity" style="letter-spacing: -0.2px;">FAQs</a>
+      <a href="#about" class="text-neutral-white font-['Geist-Regular',_sans-serif] text-base leading-[180%] hover:opacity-80 transition-opacity" style="letter-spacing: -0.2px;">About</a>
       <button
         type="button"
         class="text-neutral-white text-left font-['Geist-Regular',_sans-serif] text-base leading-[180%] font-normal relative hover:opacity-80 transition-opacity cursor-pointer"
@@ -31,8 +34,8 @@
       >
         Contact
       </button>
-    </div>
-    
+    </nav>
+
     <!-- Right side - Phone & Button -->
     <div class="flex items-center gap-6">
       <div class="text-neutral-white text-left font-['Geist-Regular',_sans-serif] text-base leading-[180%] font-normal relative hidden xl:block" style="letter-spacing: -0.2px;">
@@ -49,9 +52,12 @@
   <div class="lg:hidden flex h-[61px] relative items-center justify-between px-4 sm:px-6">
     <!-- Left side - Logo -->
     <LogoProperty1Variant2 class="shrink-0"></LogoProperty1Variant2>
-    
-    <!-- Right side - Contact Link & Button -->
+
+    <!-- Right side - Links & Button -->
     <div class="flex items-center gap-4">
+      <a href="#home" class="text-neutral-white font-['Geist-Regular',_sans-serif] text-sm leading-[180%] hover:opacity-80 transition-opacity" style="letter-spacing: -0.2px;">Home</a>
+      <a href="#faqs" class="text-neutral-white font-['Geist-Regular',_sans-serif] text-sm leading-[180%] hover:opacity-80 transition-opacity" style="letter-spacing: -0.2px;">FAQs</a>
+      <a href="#about" class="text-neutral-white font-['Geist-Regular',_sans-serif] text-sm leading-[180%] hover:opacity-80 transition-opacity" style="letter-spacing: -0.2px;">About</a>
       <button
         type="button"
         class="text-neutral-white text-left font-['Geist-Regular',_sans-serif] text-sm sm:text-base leading-[180%] font-normal relative hover:opacity-80 transition-opacity cursor-pointer"


### PR DESCRIPTION
## Summary
- support multiple pages via hash-based routing in `App.svelte`
- link to Home, FAQs, and About pages in navigation component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6862035a42508320a25d6a4c46255f0c